### PR TITLE
Use stdin.close instead of stdin.close_write

### DIFF
--- a/lib/ruby_gpg.rb
+++ b/lib/ruby_gpg.rb
@@ -58,7 +58,7 @@ module RubyGpg
     output = ""
     Open3.popen3(command) do |stdin, stdout, stderr|
       stdin.write(input) if input
-      stdin.close_write
+      stdin.close
       output << stdout.read
       error = stderr.read
       if error && !error.empty?


### PR DESCRIPTION
JRuby fails with `stdin.close_write` but works with `stdin.close`, which is equivalent afaik when using `popen3`.
