### PR TITLE
Check exit status instead of contents of stderr

### DIFF
--- a/lib/ruby_gpg.rb
+++ b/lib/ruby_gpg.rb
@@ -56,12 +56,13 @@ module RubyGpg
   
   def run_command(command, input = nil)
     output = ""
-    Open3.popen3(command) do |stdin, stdout, stderr|
+    Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
       stdin.write(input) if input
       stdin.close
       output << stdout.read
+      exitcode = wait_thr.value.exitstatus
       error = stderr.read
-      if error && !error.empty?
+      if exitcode != 0
         raise "GPG command (#{command}) failed with: #{error}"
       end
     end


### PR DESCRIPTION
This changes the way an error is detected, inspecting the exit status for a non-zero exit code rather than inferring an error if there is any content in the stderr stream. This caused false positives when gpg output warnings to stderr.

Warning - this probably doesn't work on 1.8.7 due to changes in popen3 in 1.9.3 and later. Don't know if this is an issue for you, but thought I'd flag it.
