### PR TITLE
Use binary mode for all IO operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: ruby
 sudo: true
-cache: bundler
-install:
+before_install:
   - sudo apt-get install gnupg
-  - bundle install
+  - gem install bundler
 script:
   - bundle exec rake spec
   - bundle exec rake features
 rvm:
+  - 2.3.1
+  - 2.2.5
+  - 2.1.9
   - 1.9.3
-  - 2.1.5
   - jruby
 matrix:
   fast_finish: true

--- a/features/decrypt_string.feature
+++ b/features/decrypt_string.feature
@@ -8,6 +8,6 @@ Feature: Decrypt String
     And a file named "secrets" containing "some content"
     And I encrypt the file "secrets" for "Slow Joe Crow"
     And I read the file "secrets.gpg" to a string
-    And the string should not be "secrets"
+    And the string should not be "some content"
     When I decrypt the string with passphrase "test"
-    Then the string should be "secrets"
+    Then the string should be "some content"

--- a/features/step_definitions/ruby_gpg_steps.rb
+++ b/features/step_definitions/ruby_gpg_steps.rb
@@ -62,5 +62,5 @@ Then /^the file "([^\"]*)" should contain "([^\"]*)"$/ do |filename, content|
 end
 
 Then /^the string should be "([^\"]*)"$/ do |string|
-  string.strip.should == string.strip
+  @string.strip.should == string.strip
 end

--- a/lib/ruby_gpg.rb
+++ b/lib/ruby_gpg.rb
@@ -55,16 +55,11 @@ module RubyGpg
   private
   
   def run_command(command, input = nil)
-    output = ""
-    Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
-      stdin.write(input) if input
-      stdin.close
-      output << stdout.read
-      exitcode = wait_thr.value.exitstatus
-      error = stderr.read
-      if exitcode != 0
-        raise "GPG command (#{command}) failed with: #{error}"
-      end
+    opts = { binmode: true }
+    opts[:stdin_data] = input if input
+    output, error, status = Open3.capture3(command, opts)
+    if status.exitstatus != 0
+      raise "GPG command (#{command}) failed with: #{error}"
     end
     output
   end


### PR DESCRIPTION
Why: because `#encrypt_string` and `#decrypt_string` must work correctly with non-armored data which may contain non-valid char sequences.

How: use `Open3#capture3` with a `binmode` enabled instead of `Open3#popen3`.
